### PR TITLE
⚡️ Update joints limits

### DIFF
--- a/config/joint_limits.yml
+++ b/config/joint_limits.yml
@@ -1,11 +1,11 @@
 joint_limits:
   right_wheel_joint:
     has_velocity_limits: true
-    max_velocity: 15.0
+    max_velocity: 30.0
     has_effort_limits: true
-    max_effort: 78e-3
+    max_effort: 12.6e-3
   left_wheel_joint:
     has_velocity_limits: true
-    max_velocity: 15.0
+    max_velocity: 30.0
     has_effort_limits: true
-    max_effort: 78e-3
+    max_effort: 12.6e-3


### PR DESCRIPTION
Atualizei os valores máximos das joints baseado nos motores [fingertech silversparks 33:1](https://www.fingertechrobotics.com/proddetail.php?prod=ft-Sspark16) que a gnt usa no Rozeta. A velocidade tem que ser atualizada no pacote do controlador ainda